### PR TITLE
expand text below graphs; uniformise break sizes

### DIFF
--- a/content/academics.html
+++ b/content/academics.html
@@ -206,6 +206,7 @@
   <div id="overloading">
   </div>
 </div>
+<div class="hvb"></div>
 
 <h3>Overloading Reasons</h3>
 <p class="half">

--- a/content/coop.html
+++ b/content/coop.html
@@ -95,14 +95,15 @@
   for everyone. The infamous ‘Cali or Bust’ mentality and the pandemic could have hindered
   some students from exploring opportunities in other cities that may have
   been better suited for them as well. 
-  <br /><br />
-  This also shows that Canada's brain drain is real and Canadian cities
-  are failing to attract and / or retain Canada's top talent.
 </p>
 <div class="half second">
   <span class="graph-title">favourite work locations</span>
   <div id="favourite-location"> </div>
 </div>
+<p class="full">
+  This also shows that Canada's brain drain is real and Canadian cities
+  are failing to attract and / or retain Canada's top talent.
+</p>
 
 <div class="vbx2"></div>
 </div>
@@ -114,22 +115,26 @@
   compensation had on average tripled in comparison to the first co-op term.
   </span>
   Average hourly compensation per co-op term were <b>$21.48, $32.07, $32.18, $55.35, $57.47, $60.36</b> (in CAD).
-  <br /><br />
-  The difference could be explained by the exchange rate between the USD and the CAD, as more respondents 
-  started working in the US, and an increase in salaries and
-  stipends to compensate for the difference in living costs between different
-  locations. For example, San Francisco housing typically costs between
-  $1,500 to $2,500 per month. In comparison, Waterloo housing costs approximately $700 per month. 
-  <br /><br />
-  The median hourly compensation may be lower in the last co-op because respondents were not able to work in 
-  the US or worked for US companies on a Canadian payroll and received lower compensation as a result.
-  <br /><br />
-  Note that some of these values include other types of compensation such as stipend and others may not.
 </p>
 <div class="half second">
   <span class="graph-title">hourly compensation per co-op term in CAD</span>
   <div id="salary"></div>
 </div>
+
+<p class="half">
+  The difference could be explained by the exchange rate between the USD and the CAD, as more respondents 
+  started working in the US, and an increase in salaries and
+  stipends to compensate for the difference in living costs between different
+  locations. For example, San Francisco housing typically costs between
+  $1,500 to $2,500 per month. In comparison, Waterloo housing costs approximately $700 per month. 
+</p>
+
+<p class="half second">
+  The median hourly compensation may be lower in the last co-op because respondents were not able to work in
+  the US or worked for US companies on a Canadian payroll and received lower compensation as a result.
+  <br /><br />
+  Note that some of these values include other types of compensation such as stipend while others may not.
+</p>
 
 <div class="vbx2"></div>
 
@@ -347,19 +352,19 @@ imply higher job satisfaction.
   respondents in the class.
   <br/>
   Note: There were about 30-42 men and 8-9 women who responded to co-op salaries.
-  <br /><br />
-
-  However, this does not suggest that there is no gender bias in the long term.
-  In fact, according to <a target="_blank"
-    href="https://research-content.glassdoor.com/app/uploads/sites/2/2016/03/Glassdoor-Gender-Pay-Gap-Study.pdf">a
-    Glassdoor study</a>,
-  "younger workers face a smaller gender pay gap than older workers." This
-  finding is not exclusive to the tech industry.
 </p>
 <div class="half second">
   <span class="graph-title">salary per co-op term</span>
   <div id="gender-salary"></div>
 </div>
+<p class="full">
+  However, this does not suggest that there is no gender bias in the long term.
+  In fact, according to
+  <a target="_blank"
+    href="https://research-content.glassdoor.com/app/uploads/sites/2/2016/03/Glassdoor-Gender-Pay-Gap-Study.pdf">
+    a Glassdoor study</a>, "younger workers face a smaller gender pay gap than older
+  workers." This finding is not exclusive to the tech industry.
+</p>
 
 <div class="vbx2"></div>
 <div class="long_version">
@@ -396,20 +401,22 @@ imply higher job satisfaction.
   to get paid. Side projects are often seen as the closest thing to software
   work experience, making it a great time investment to compensate for any lack
   of work experience.
-
-  <br /> <br />
-  It is important to mention that <b>side projects and hackathons are not the only way to find
-  a job</b>. There have been many less-practiced methods students have used to
-  find job opportunities such as referrals, networking, etc.
-  <br /> <br />
-  It is just as important to note that <b>students who are not involved in software-related
-  extracurriculars still find great jobs</b>. In fact,
-  many SE students and faculty encourage pursuing interests besides software.
 </p>
 <div class="half second">
   <span class="graph-title">side project commitment compared to hourly salary</span>
   <div id="side-salary"></div>
 </div>
+
+<p class="half">
+  It is important to mention that <b>side projects and hackathons are not the only way to find
+  a job</b>. There have been many less-practiced methods students have used to
+  find job opportunities such as referrals, networking, etc.
+</p>
+<p class="half second">
+  It is just as important to note that <b>students who are not involved in software-related
+  extracurriculars still find great jobs</b>. In fact,
+  many SE students and faculty encourage pursuing interests besides software.
+</p>
 
 <div class="vbx2"></div>
 </div>

--- a/content/end.html
+++ b/content/end.html
@@ -5,7 +5,7 @@
   </span>
 </p>
 
-<div class="vbx3"></div>
+<div class="vbx2"></div>
 <h2> Acknowledgements</h2>
 <p class="full">
 This project wouldn't have been possible without the help of some great people:

--- a/content/exchange.html
+++ b/content/exchange.html
@@ -138,4 +138,3 @@
     period of time. Another plus is to be able to take some courses not offered at
     UWaterloo (NLP anyone?).
 </p>
-<div class="vb"></div>

--- a/content/finances.html
+++ b/content/finances.html
@@ -93,26 +93,26 @@
   The co-op program can help students earn money to pay off debts and expenses as they work towards their degree.
   <br /> <br />
   In 2019, the average student debt in Ontario was around $19,000 compared to $20k - $30k average debt among this survey respondents.
-  <br /> <br /> <!-- Newline -->
-  Engineering at Waterloo is also a more costly program. 
-  <br/>
-  The average undergraduate tuition for Canadian citizens studying in Canada is around $6,500/year compared to $17,100/year for SE.
-  The average undergraduate tuition for international students studying in Canada is around $29,700/year compared to $61,200/year for SE
 </p>
 <div class="half second">
   <span class="graph-title">debt among students</span>
   <div id="new-debt"></div>
 </div>
+<p class="full">
+  Engineering at Waterloo is also a more costly program.
+  <br/>
+  The average undergraduate tuition for Canadian citizens studying in Canada is around $6,500/year compared to $17,100/year for SE.
+  The average undergraduate tuition for international students studying in Canada is around $29,700/year compared to $61,200/year for SE
+</p>
 <!-- Resources: 
   https://www150.statcan.gc.ca/n1/pub/75-006-x/2020001/article/00005-eng.htm
   https://www.topuniversities.com/student-info/student-finance/how-much-does-it-cost-study-canada
   https://uwaterloo.ca/future-students/financing/tuition
 -->
 
-<div class="vbx2"></div>
-
 <!-- TODO: Consider removing these sections -->
 <!--
+  <div class="vbx2"></div>
 <h3> Preferred Shopping Method </h3>
 <p class="half">
   <span class="big">

--- a/content/future.html
+++ b/content/future.html
@@ -20,7 +20,7 @@
   <div id="post-location"></div>
 </div>
 
-<div class="vbx3"></div>
+<div class="vbx2"></div>
 
 <p class="half">
   <span class="big">
@@ -36,7 +36,7 @@
   <div id="ft-company"></div>
 </div>
 
-<div class="vbx3"></div>
+<div class="vbx2"></div>
 
 <p class="half">
   <span class="big">
@@ -52,7 +52,7 @@
   <div id="coop-conversion"></div>
 </div>
 
-<div class="vbx3"></div>
+<div class="vbx2"></div>
 <div class="long_version">
 <p class="half">
   <span class="big">
@@ -68,7 +68,7 @@
   <div id="peng"></div>
 </div>
 
-<div class="vbx3"></div>
+<div class="vbx2"></div>
 </div>
 <p class="half">
   <span class="big">
@@ -84,7 +84,7 @@
   <div id="cont-fydp"></div>
 </div>
 
-<div class="vbx3"></div>
+<div class="vbx2"></div>
 
 <p class="half">
   <span class="big">
@@ -107,18 +107,21 @@
     will average $284,728 CAD, with a median of $260,000. This number
     includes all forms of remuneration eg. signing bonuses and equity.
   </span>
-  The exchange rate used for this question and the ones that follow was 1.3
-  CAD per 1 USD. That rate was accurate at the time the survey was shared,
-  but the rate is 1.2 as of writing.
-  <br /><br />
-  Since 77% of respondents will be relocating to the US, we can estimate
-  the new average and median earnings to actually be $267,882 and $244,600 CAD.
-  <!-- 260k*(1 + 0.77(1.2/1.3 - 1)). -->
 </p>
 <div class="half second">
   <span class="graph-title">new grad total first year compensation</span>
   <div id="ft-total"></div>
 </div>
+<p class="half">
+  The exchange rate used for this question and the ones that follow was 1.3
+  CAD per 1 USD. That rate was accurate at the time the survey was shared,
+  but the rate is 1.2 as of writing.
+</p>
+<p class="half second">
+  Since 77% of respondents will be relocating to the US, we can estimate
+  the new average and median earnings to actually be $267,882 and $244,600 CAD.
+  <!-- 260k*(1 + 0.77(1.2/1.3 - 1)). -->
+</p>
 
 <div class="vbx2"></div>
 <p class="half">
@@ -150,6 +153,11 @@
   <span class="graph-title">new grad profit sharing in compensation</span>
   <div id="ft-stock"></div>
 </div>
+<p class="full">
+  There are extreme outliers that skewed the mean and median greatly.
+  <br />
+  With the new rate, the results are $89,742 and $30,505 CAD.
+</p>
 
 <div class="vbx2"></div>
 <p class="half">
@@ -178,15 +186,16 @@
     accepting full-time roles. 
   </span>
   It is great to see the class value a positive environment above compensation.
-  <br /><br />
-  In contrast to most other industries, software recruitment has remained
-  relatively unaffected in the face of a global pandemic. Only 1 respondent factored
-  job security in their decision-making. 
 </p>
 <div class="half second">
   <span class="graph-title">factors affecting post-graduation plans</span>
   <div id="motivation"></div>
 </div>
+<p class="full">
+  In contrast to most other industries, software recruitment has remained
+  relatively unaffected in the face of a global pandemic. Only 1 respondent factored
+  job security in their decision-making.
+</p>
 
 <div class="vbx2"></div>
 <div class="long_version">
@@ -197,14 +206,15 @@
   </span>
   Moving away is a big change. There's a fairly even split among students who would like to return home or stay abroad, while the rest of students haven't decided yet.
   This goes to show that everyone has different goals and each student should find what's important to them.
-  <br/><br/>
-  One common tip from alumni is to pursue what makes you happy and aligns with your values.
-  This way, you can find the most happiness in what you do, whether that's close to home or abroad.
 </p>
 <div class="half second">
   <span class="graph-title">do you plan to return to your home country?</span>
   <div id="post-return-home"></div>
 </div>
+<p class="full">
+  One common tip from alumni is to pursue what makes you happy and aligns with your values.
+  This way, you can find the most happiness in what you do, whether that's close to home or abroad.
+</p>
 
 <div class="vbx2"></div>
 </div>

--- a/content/health.html
+++ b/content/health.html
@@ -11,6 +11,7 @@
   <span class="graph-title">how many times did you fall ill or were injured?</span>
   <div id="sickness"></div>
 </div>
+<div class="hvb"></div>
 
 <div class="long_version">
 <p class="half">
@@ -26,7 +27,7 @@
     <div id="health-insurance"></div>
   </div>
 </div>
-<div class="vbx4"></div>
+<div class="vbx2"></div>
 
 <h3> Mental Health </h3>
 <p class="half">
@@ -35,15 +36,17 @@
   </span>
   Half of the respondents reported struggling with mental health problems before and during university. 
   The majority of those reported developing mental health struggles after starting university.
-  <br/> <br/>
-  Starting post-secondary education can bring a lot of change and excitement to a student's life.
-  With that change, there are many factors that can also cause students to struggle with their mental health.
-  It's important to look out for yourself and one another as everyone is fighting a different battle and may need support at any moment.
 </p>
 <div class="half second">
   <span class="graph-title">have you struggled with mental health?</span>
   <div id="mental-health-count"></div>
 </div>
+<p class="full">
+  Starting post-secondary education can bring a lot of change and excitement to a student's life.
+  With that change, there are many factors that can also cause students to struggle with their mental health.
+  It's important to look out for yourself and one another as everyone is fighting a different battle and may need support at any moment.
+</p>
+<div class="vb"></div>
 
 <p class="half">
     <span class="big">
@@ -58,7 +61,7 @@
     <div id="mental-health-issues"></div>
   </div>
 
-<div class="vbx4"></div>
+<div class="vbx2"></div>
 
 <h3>Imposter Syndrome</h3>
 <p class="half">
@@ -80,7 +83,7 @@
   <span class="graph-title">do you still feel like an imposter?</span>
   <div id="imposter-syndrome-now" class="graph-center"></div>
 </div>
-<div class="vbx4"></div>
+<div class="vbx2"></div>
 
 <h3> Physical Health </h3>
 <p class="half">
@@ -98,6 +101,7 @@
   <span class="graph-title">exercise frequency</span>
   <div id="exercise-frequency"></div>
 </div>
+<div class="vb"></div>
 
 <p class="half">
     <span class="big">
@@ -125,6 +129,7 @@
     <span class="graph-title">intramural sport participation rate</span>
     <div id="intramurals"></div>
 </div>
+<div class="vb"></div>
 
 <p class="half">
     <span class="big">
@@ -140,7 +145,7 @@
     <div id="weight"></div>
 </div>
 </div>
-<div class="vbx4"></div>
+<div class="vbx2"></div>
 
 <h3> Controlled Substances </h3>
 <p class="half">
@@ -153,5 +158,3 @@
   <span class="graph-title">kinds of recreational controlled substances used</span>
   <div id="controlled-substances"></div>
 </div>
-
-<div class="vbx4"></div>

--- a/content/lifestyle.html
+++ b/content/lifestyle.html
@@ -11,14 +11,16 @@
   C++ is one of the first languages that SE students encounter in their courses.
   It provides a strong programming foundation and is highly portable, making it an ideal choice for multi-platform development.
   It also has applications in enterprise codebases, so students may encounter it over co-op as well.
-  <br/> <br/>
-  Many students encounter web development either during co-op or for side projects.
-  This may explain why many students pick up JavaScript and TypeScript.
 </p>
 <div class="half second">
   <span class="graph-title">favourite programming language</span>
   <div id="programming-language"></div>
 </div>
+<p class="full">
+  Many students encounter web development either during co-op or for side projects.
+  This may explain why many students pick up JavaScript and TypeScript.
+</p>
+<div class="vb"></div>
 
 <p class="half">
   <span class="big">
@@ -76,7 +78,7 @@
   <div id="cooking-frequency"></div>
 </div>
 
-<div class="vbx4"></div>
+<div class="vbx2"></div>
 </div>
 <div class="long_version">
 <h3> Dining </h3>
@@ -104,7 +106,7 @@
   <div id="eating-out-frequency"></div>
 </div>
 
-<div class="vbx4"></div>
+<div class="vbx2"></div>
 </div>
 <h3> Sleep </h3>
 <p class="half">
@@ -116,14 +118,14 @@
   possibly due to work or personal reasons (gaming).
   <br /> <br />
   Sleeping after 6 AM might sound crazy, but then again, some of these students
-  also willingly go to 24 hour hackathons.
+  also willingly go to 24-hour hackathons.
 </p>
 <div class="half second">
   <span class="graph-title">usual sleep time</span>
   <div id="sleep-time"></div>
 </div>
 
-<div class="vbx2"></div>
+<div class="vb"></div>
 
 <div class="long_version">
 <p class="half">
@@ -139,7 +141,7 @@
   <div id="sleep-duration"></div>
 </div>
 
-<div class="vbx4"></div>
+<div class="vbx2"></div>
 </div>
 
 <h3> Travel Locations </h3>
@@ -192,7 +194,7 @@
   </p>
 </p>
 
-<div class="vbx4"></div>
+<div class="vbx2"></div>
 
 <h3> Extracurriculars </h3>
 <p class="half">
@@ -209,7 +211,7 @@
   <div id="extracurriculars"></div>
 </div>
 
-<div class="vbx3"></div>
+<div class="vbx2"></div>
 <div class="long_version">
 <p class="half">
   <span class="big">
@@ -226,7 +228,7 @@
   <div id="design-team"></div>
 </div>
 
-<div class="vbx3"></div>
+<div class="vbx2"></div>
 </div>
 <p class="half">
   <span class="big">

--- a/content/misc.html
+++ b/content/misc.html
@@ -185,14 +185,15 @@ some stories over the past 5 years.
   <br /><br />
   Of those who responded, Waterloo SE students cried once a term on mode and median,
   1.7 times on average.
-  <br /><br />
-  It is difficult to determine how these results map onto the total SE student population.
-  A non-answer could imply a (low or high) extremity.
 </p>
 <div class="half second">
   <span class="graph-title">average frequency of crying in a term</span>
   <div id="crying"></div>
 </div>
+<p class="full">
+  It is difficult to determine how these results map onto the total SE student population.
+  A non-answer could imply a (low or high) extremity.
+</p>
 
 <div class="vbx2"></div>
 </div>
@@ -235,5 +236,3 @@ some stories over the past 5 years.
   <div id="se21-grad"></div>
 </div>
 </div>
-
-<div class="vbx2"></div>

--- a/content/relationships.html
+++ b/content/relationships.html
@@ -41,7 +41,7 @@
   would explain why 63 % of respondents spent on average less than a day with
   their parents in person.
 </p>
-<div class="vb"></div>
+<div class="vbx2"></div>
 
 <h2>Friendships</h2>
 <div class="long_version">
@@ -68,7 +68,9 @@
     <b> Interactive: </b> Click on a provided filter to hide or display the plot for that filter.
   </p>
 </div>
+<div class="vb"></div>
 </div>
+
 <p class="full">
   <span class="big">
     From classmates to friends..?
@@ -161,6 +163,7 @@
   never had one during university. Someone even boasted having 9 sexual partners
   during their undergraduate studies.
 </p>
+<div class="vb"></div>
 
 <div class="long_version">
 <p class="full">
@@ -184,7 +187,9 @@
   </span>
   <div id="romance-cheating-reasons"></div>
 </div>
+<div class="vb"></div>
 </div>
+
 <h3> Growth </h3>
 <p class="full">
   <span class="big">

--- a/content/transfers.html
+++ b/content/transfers.html
@@ -35,13 +35,14 @@ an Excellent academic standing.
 </span>
 The Engineering program has a relatively rigid course schedule which offers students the flexibility to choose courses usually only in their fourth year. 
 The Computer Science program, on the other hand, is less restrictive and allows students to customize their schedules freely. 
-<br /> <br />
-Other reasons for transferring included avoiding a course, graduating early, and accommodating for an exchange term. 
 </p>
 <div class="half second">
     <span class="graph-title">reasons for transferring</span>
     <div id="reasons-transferred"></div>
 </div>
+<p class="full">
+    Other reasons for transferring included avoiding a course, graduating early, and accommodating an exchange term.
+</p>
 <div class="vbx2"></div>
 
 <h3> Disliked Courses </h3>


### PR DESCRIPTION
i'm opening these changes in a separate PR since they are a point of contention (and i'd like #59 to go in earlier).

### changes
- uniformise breaks between sections, paragraphs (vbs, vbx2 instead of vbx3 or vbx4)
- let text go below graphs (see examples below)
  
  before:

  ![image](https://user-images.githubusercontent.com/11150920/124204177-7eb5b600-daac-11eb-9b66-f05359ba941b.png)
  
  ![image](https://user-images.githubusercontent.com/11150920/124204316-cf2d1380-daac-11eb-96aa-880f51257048.png)

  after:
  
  ![image](https://user-images.githubusercontent.com/11150920/124204229-9f7e0b80-daac-11eb-89fa-f56b95717059.png)
  
  ![image](https://user-images.githubusercontent.com/11150920/124204331-d94f1200-daac-11eb-9894-5a987ba826fc.png)
  
  (vertically, the text looks like this:)
  
  ![image](https://user-images.githubusercontent.com/11150920/124204452-19ae9000-daad-11eb-80eb-6cab24b4cf65.png)